### PR TITLE
Fix for rake db:reset error

### DIFF
--- a/lib/acts_as_opengraph/active_record/acts/opengraph.rb
+++ b/lib/acts_as_opengraph/active_record/acts/opengraph.rb
@@ -10,6 +10,7 @@ module ActiveRecord
         def acts_as_opengraph(options = {})
           # don't allow multiple calls
           return if included_modules.include? InstanceMethods
+          return unless table_exists?
           
           extend ClassMethods
           
@@ -79,7 +80,7 @@ module ActiveRecord
           alt_names = alternative_names_for(att_name)
           columns_to_check = [att_name] + alt_names
           columns_to_check.each do |column_name| 
-            return column_name.to_sym if table_exists? && column_names.include?(column_name.to_s)
+            return column_name.to_sym if column_names.include?(column_name.to_s)
           end
           
           # Define placeholder method


### PR DESCRIPTION
When I used rake db:reset, I kept getting a column_names error from acts_as_opengraph (trace below). I fixed it by returning from the acts_as_opengraph method if table_exists? fails. That seems to have done the trick.

<pre><code>Could not find table 'posts'
/Users/jeff/ruby/app/pristine/ruby/1.9.1/gems/activerecord-3.0.1/lib/active_record/connection_adapters/sqlite_adapter.rb:295:in `table_structure'
/Users/jeff/ruby/app/pristine/ruby/1.9.1/gems/activerecord-3.0.1/lib/active_record/connection_adapters/sqlite_adapter.rb:186:in `columns'
/Users/jeff/ruby/app/pristine/ruby/1.9.1/gems/activerecord-3.0.1/lib/active_record/base.rb:679:in `columns'
/Users/jeff/ruby/app/pristine/ruby/1.9.1/gems/activerecord-3.0.1/lib/active_record/base.rb:692:in `column_names'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:82:in `block in alternative_column_name_for'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:81:in `each'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:81:in `alternative_column_name_for'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:22:in `block in acts_as_opengraph'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:21:in `each'
/Users/jeff/Ruby/acts_as_opengraph/lib/acts_as_opengraph/active_record/acts/opengraph.rb:21:in `acts_as_opengraph'
/Users/jeff/ruby/app/app/models/post.rb:3:in `<class:Post>'
</code></pre>
